### PR TITLE
feat: Add pizza detail view with ingredients and permissions

### DIFF
--- a/pizzeria/serializers.py
+++ b/pizzeria/serializers.py
@@ -5,7 +5,8 @@ from .models import Pizza, Ingredient
 class IngredientSerializer(serializers.ModelSerializer):
     class Meta:
         model = Ingredient
-        fields = ['name']
+        fields = ["name"]
+
 
 class PizzaSerializer(serializers.ModelSerializer):
     ingredients_count = serializers.SerializerMethodField()
@@ -16,6 +17,7 @@ class PizzaSerializer(serializers.ModelSerializer):
 
     def get_ingredients_count(self, obj):
         return obj.ingredients.count()
+
 
 class PizzaDetailSerializer(serializers.ModelSerializer):
     ingredients = IngredientSerializer(many=True, read_only=True)

--- a/pizzeria/serializers.py
+++ b/pizzeria/serializers.py
@@ -1,13 +1,25 @@
 from rest_framework import serializers
-from .models import Pizza
+from .models import Pizza, Ingredient
 
+
+class IngredientSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Ingredient
+        fields = ['name']
 
 class PizzaSerializer(serializers.ModelSerializer):
     ingredients_count = serializers.SerializerMethodField()
 
     class Meta:
         model = Pizza
-        fields = ["name", "price", "ingredients_count", "status"]
+        fields = ["name", "price", "ingredients_count"]
 
     def get_ingredients_count(self, obj):
         return obj.ingredients.count()
+
+class PizzaDetailSerializer(serializers.ModelSerializer):
+    ingredients = IngredientSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Pizza
+        fields = ["name", "price", "status", "ingredients"]

--- a/pizzeria/urls.py
+++ b/pizzeria/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
-from .views import PizzaListView
+from .views import PizzaListView, PizzaDetailView
 
 urlpatterns = [
     path("pizzas/", PizzaListView.as_view(), name="pizza-list"),
+    path("pizzas/<int:pk>/", PizzaDetailView.as_view(), name="pizza-detail"),
 ]

--- a/pizzeria/views.py
+++ b/pizzeria/views.py
@@ -1,6 +1,8 @@
 from rest_framework import generics
+from rest_framework.exceptions import PermissionDenied
+from rest_framework.response import Response
 from .models import Pizza
-from .serializers import PizzaSerializer
+from .serializers import PizzaSerializer, PizzaDetailSerializer
 
 
 class PizzaListView(generics.ListAPIView):
@@ -12,3 +14,18 @@ class PizzaListView(generics.ListAPIView):
             return Pizza.objects.all()
         else:
             return Pizza.objects.filter(status="active")
+
+
+class PizzaDetailView(generics.RetrieveAPIView):
+    queryset = Pizza.objects.all()
+    serializer_class = PizzaDetailSerializer
+
+    def retrieve(self, request, *args, **kwargs):
+        instance = self.get_object()
+        user = request.user
+
+        if instance.status == 'inactive' and not (user.is_authenticated and (user.is_staff or user.is_superuser)):
+            raise PermissionDenied("You do not have permission to view inactive pizzas.")
+
+        serializer = self.get_serializer(instance)
+        return Response(serializer.data)

--- a/pizzeria/views.py
+++ b/pizzeria/views.py
@@ -24,8 +24,12 @@ class PizzaDetailView(generics.RetrieveAPIView):
         instance = self.get_object()
         user = request.user
 
-        if instance.status == 'inactive' and not (user.is_authenticated and (user.is_staff or user.is_superuser)):
-            raise PermissionDenied("You do not have permission to view inactive pizzas.")
+        if instance.status == "inactive" and not (
+            user.is_authenticated and (user.is_staff or user.is_superuser)
+        ):
+            raise PermissionDenied(
+                "You do not have permission to view inactive pizzas."
+            )
 
         serializer = self.get_serializer(instance)
         return Response(serializer.data)


### PR DESCRIPTION
Create a new API endpoint `/pizzas/<int:pk>/` to retrieve details for a single pizza. This endpoint includes the list of ingredients associated with the pizza. Implement permission logic in the view to restrict access to inactive pizzas: only authenticated staff or superusers can view inactive pizzas. Add `IngredientSerializer` and `PizzaDetailSerializer` to support the new view.